### PR TITLE
fix for expired keys during connection

### DIFF
--- a/src/service/socket.io/shared.js
+++ b/src/service/socket.io/shared.js
@@ -228,7 +228,7 @@ const getKeysInfo = async (options) => {
     for (let keysIndex in keys) {
         const key = keys[keysIndex]
         const obj = result[key]
-        if (obj.type === 'string') {
+        if (obj.type === 'string' || obj.type === 'none') {
 
             continue
         }


### PR DESCRIPTION
When you connect to live redis with lots of keys, after fetching keys some get expired, when it happens you get:

"[ERROR] TypeError: Cannot read property '1' of undefined
    at getKeysInfo (/usr/lib/node_modules/p3x-redis-ui/node_modules/p3x-redis-ui-server/src/service/socket.io/shared.js:255:43)
    at processTicksAndRejections (internal/process/task_queues.js:86:5)"

Redis returns type 'none' for expired/non existent keys.